### PR TITLE
Fix allow function argument decoding error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 # Available at setup time due to pyproject.toml
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # Note:
 #   Sort input source files if you glob sources to ensure bit-for-bit


### PR DESCRIPTION
Avoids a utf-8 decoding error when accepting a connection with an allow
function by properly wrapping the function in a version that passes
pubkey as a `bytes`.