### PR TITLE
Fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 # Available at setup time due to pyproject.toml
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 # Note:
 #   Sort input source files if you glob sources to ensure bit-for-bit

--- a/src/oxenmq.cpp
+++ b/src/oxenmq.cpp
@@ -62,6 +62,7 @@ OxenMQ_Init(py::module& mod)
         .def(py::self != py::self)
         .def_property_readonly("service_node", &ConnectionID::sn)
         .def_property_readonly("pubkey", [](const ConnectionID& c) { return py::bytes(c.pubkey()); })
+        .def(py::hash(py::self))
         ;
     py::class_<address>(mod, "Address")
         .def(py::init<std::string_view>(), "addr"_a,

--- a/src/oxenmq.cpp
+++ b/src/oxenmq.cpp
@@ -153,11 +153,13 @@ This typically protects administrative commands like shutting down or access to 
     msg
         .def_property_readonly("is_reply", [](const Message& m) { return !m.reply_tag.empty(); },
                 "True if this message is expecting a reply (i.e. it was received on a request_command endpoint)")
-        .def_readonly("remote", &Message::remote, R"(Some sort of remote address from which the request came.
+        .def_readonly("remote", &Message::remote, py::return_value_policy::copy,
+                R"(Some sort of remote address from which the request came.
 
 Typically the IP address string for TCP connections and "localhost:UID:GID:PID" for unix socket IPC connections.)")
-        .def_readonly("conn", &Message::conn, "The connection ID info for routing a reply")
-        .def_readonly("access", &Message::access,
+        .def_readonly("conn", &Message::conn, py::return_value_policy::copy,
+                "The connection ID info for routing a reply")
+        .def_readonly("access", &Message::access, py::return_value_policy::copy,
                 "The access level of the invoker (which can be higher than the access level required for the command category")
         .def("dataview", [](const Message& m) {
             py::list l;


### PR DESCRIPTION
- Makes ConnectionIDs hashable in Python
- Make allow_connection properly optional
- Fix Message properties (like .conn) being broken if stored because of internal oxenmq Message reuse.