### PR TITLE
Expose setting auth level on outgoing connection

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -31,7 +31,7 @@ local debian_pipeline(name,
       image: image,
       pull: 'always',
       [if allow_fail then 'failure']: 'ignore',
-      environment: { SSH_KEY: { from_secret: 'SSH_KEY' } },
+      environment: { SSH_KEY: { from_secret: 'SSH_KEY' }, PIP_BREAK_SYSTEM_PACKAGES: '1' },
       commands: [
                   'echo "Building on ${DRONE_STAGE_MACHINE}"',
                   'echo "man-db man-db/auto-update boolean false" | debconf-set-selections',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 # Available at setup time due to pyproject.toml
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 # Note:
 #   Sort input source files if you glob sources to ensure bit-for-bit


### PR DESCRIPTION
This is necessary to allow a remote to issue authenticated commands back to us.