### PR TITLE
Fix python binding segfault

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -16,6 +16,7 @@ local apt_get_quiet = 'apt-get -o=Dpkg::Use-Pty=0 -q';
 local debian_pipeline(name,
                       image,
                       arch='amd64',
+                      distro='$$(lsb_release -sc)',
                       deps=default_deps,
                       extra_cmds=[],
                       jobs=6,
@@ -41,9 +42,9 @@ local debian_pipeline(name,
                   if loki_repo then [
                     'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y lsb-release',
                     'cp contrib/deb.oxen.io.gpg /etc/apt/trusted.gpg.d',
-                    'echo deb http://deb.oxen.io $$(lsb_release -sc) main >/etc/apt/sources.list.d/oxen.list',
-                    'echo deb http://deb.oxen.io/beta $$(lsb_release -sc) main >>/etc/apt/sources.list.d/oxen.list',
-                    'echo deb http://deb.oxen.io/staging $$(lsb_release -sc) main >>/etc/apt/sources.list.d/oxen.list',
+                    'echo deb http://deb.oxen.io ' + distro + ' main >/etc/apt/sources.list.d/oxen.list',
+                    'echo deb http://deb.oxen.io/beta ' + distro + ' main >>/etc/apt/sources.list.d/oxen.list',
+                    'echo deb http://deb.oxen.io/staging ' + distro + ' main >>/etc/apt/sources.list.d/oxen.list',
                     'eatmydata ' + apt_get_quiet + ' update',
                   ] else []
                 ) + [
@@ -92,14 +93,14 @@ local mac_builder(name,
 
 [
   // Various debian builds
-  debian_pipeline('Debian sid (amd64)', docker_base + 'debian-sid'),
+  debian_pipeline('Debian sid (amd64)', docker_base + 'debian-sid', distro='sid'),
   debian_pipeline('Debian stable (i386)', docker_base + 'debian-stable/i386'),
   debian_pipeline('Debian buster (amd64)', docker_base + 'debian-buster'),
   debian_pipeline('Ubuntu latest (amd64)', docker_base + 'ubuntu-rolling'),
   debian_pipeline('Ubuntu LTS (amd64)', docker_base + 'ubuntu-lts'),
 
   // ARM builds (ARM64 and armhf)
-  debian_pipeline('Debian sid (ARM64)', docker_base + 'debian-sid', arch='arm64', jobs=4),
+  debian_pipeline('Debian sid (ARM64)', docker_base + 'debian-sid', arch='arm64', jobs=4, distro='sid'),
   debian_pipeline('Debian stable (armhf)', docker_base + 'debian-stable/arm32v7', arch='arm64', jobs=4),
 
   // Macos builds:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 # Available at setup time due to pyproject.toml
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 # Note:
 #   Sort input source files if you glob sources to ensure bit-for-bit


### PR DESCRIPTION
This fixes a segfault in the reply handling code, where the destructor of a `py::function` wasn't necessarily happening with the GIL held, which could make Python segfault.

The solution that was here to address this didn't work because it was relying on std::optionals, but it is possible (and apparently sometimes happens) that the std::function this lambda gets stuffed into gets moved (or maybe copied?), which then results in *two* lambda destructions: we were correctly dealing with the one that eventually gets called by clearing things properly when it gets called, but the temporary destructor also fires, and that is the one that broke.

This changes it to instead leak bare pointers into the lambda and then recapture them inside when we get called; since we are guaranteed to be called exactly once, this recaptures them without losing them but doesn't incur destruction of a py::function deep in oxenmq (outside of GIL scope).