### PR TITLE
fix: change setup cpp version to 20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ __version__ = "1.0.5"
 ext_modules = [Pybind11Extension(
         "oxenmq",
         ["src/oxenmq.cpp"],
-        cxx_std=17,
+        cxx_std=20,
         libraries=["oxenmq"],
         ),
 ]


### PR DESCRIPTION
## Issue
Encountered an issue when running `pip install .` on the repo to install it. See attached log.

## Solution
Solved by changing the cpp version in setup.py to 20. This change allows `pip install .` to run successfully.

## Error
[oxen-pyoxenmq-error.log](https://github.com/user-attachments/files/16884237/oxen-pyoxenmq-error.log)
